### PR TITLE
Tomek/minify docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ ENV NODE_ENV=production
 EXPOSE 3001
 COPY --from=production-dependencies-env /app/node_modules /app/node_modules
 COPY --from=build-env /app/apps/backend/dist /app/dist
-ENTRYPOINT ["node", "dist/index.js"]
+CMD ["dist/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ COPY --from=build-env /app/apps/frontend/build/client /usr/share/nginx/html
 EXPOSE 80
 ENTRYPOINT ["nginx", "-g", "daemon off;"] 
 
-FROM gcr.io/distroless/nodejs22 AS production-backend
+FROM gcr.io/distroless/nodejs22:nonroot AS production-backend
 WORKDIR /app
 ENV NODE_ENV=production
 EXPOSE 3001

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
-FROM node:22-alpine AS development-dependencies-env
+FROM node:22-slim AS development-dependencies-env
 WORKDIR /app
 COPY package.json package-lock.json /app/
 COPY apps/frontend/package.json /app/apps/frontend/package.json
 COPY apps/backend/package.json /app/apps/backend/package.json
 RUN npm ci
 
-FROM node:22-alpine AS production-dependencies-env
+FROM node:22-slim AS production-dependencies-env
 WORKDIR /app
 COPY package.json package-lock.json /app/
 COPY apps/frontend/package.json /app/apps/frontend/package.json
 COPY apps/backend/package.json /app/apps/backend/package.json
 RUN npm ci --omit=dev --workspace apps/backend
 
-FROM node:22-alpine AS build-env
+FROM node:22-slim AS build-env
 COPY . /app/
 COPY --from=development-dependencies-env /app/node_modules /app/node_modules
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
-FROM node:23-alpine AS development-dependencies-env
+FROM node:22-alpine AS development-dependencies-env
 WORKDIR /app
 COPY package.json package-lock.json /app/
 COPY apps/frontend/package.json /app/apps/frontend/package.json
 COPY apps/backend/package.json /app/apps/backend/package.json
 RUN npm ci
 
-FROM node:23-alpine AS production-dependencies-env
+FROM node:22-alpine AS production-dependencies-env
 WORKDIR /app
 COPY package.json package-lock.json /app/
 COPY apps/frontend/package.json /app/apps/frontend/package.json
 COPY apps/backend/package.json /app/apps/backend/package.json
-RUN npm ci --omit=dev
+RUN npm ci --omit=dev --workspace apps/backend
 
-FROM node:23-alpine AS build-env
+FROM node:22-alpine AS build-env
 COPY . /app/
 COPY --from=development-dependencies-env /app/node_modules /app/node_modules
 WORKDIR /app
@@ -24,16 +24,10 @@ COPY --from=build-env /app/apps/frontend/build/client /usr/share/nginx/html
 EXPOSE 80
 ENTRYPOINT ["nginx", "-g", "daemon off;"] 
 
-FROM node:23-alpine AS production-backend
+FROM gcr.io/distroless/nodejs22 AS production-backend
 WORKDIR /app
-COPY package.json package-lock.json /app/
-COPY apps/frontend/package.json /app/apps/frontend/package.json
-COPY apps/backend/package.json /app/apps/backend/package.json
-COPY --from=production-dependencies-env /app/node_modules /app/node_modules
-RUN npm prune --workspace apps/backend
-COPY --from=build-env /app/apps/backend/dist /app/dist
-RUN chown node:node ./
-USER node
-ENV NODE_ENV production
+ENV NODE_ENV=production
 EXPOSE 3001
+COPY --from=production-dependencies-env /app/node_modules /app/node_modules
+COPY --from=build-env /app/apps/backend/dist /app/dist
 ENTRYPOINT ["node", "dist/index.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,9 +10,7 @@ services:
     networks:
       - traefik
     restart: unless-stopped
-    env_file:
-      - path: ./.env
-        required: true
+    env_file: .env
     environment:
       TRAEFIK_ENTRYPOINTS_HTTPS: true
       TRAEFIK_ENTRYPOINTS_HTTPS_ADDRESS: :443
@@ -48,9 +46,7 @@ services:
     image: postgres:17-alpine
     restart: unless-stopped
     user: postgres
-    env_file:
-      - path: ./.env
-        required: true
+    env_file: .env
     environment:
       POSTGRES_USER: ${DATABASE_USER}
       POSTGRES_PASSWORD: ${DATABASE_PASSWORD}
@@ -76,11 +72,10 @@ services:
     build:
       context: ./
       target: production-backend
+    image: aplikacja-konie-backend
     # ports:
     #   - 3001:3001
-    env_file:
-      - path: ./.env
-        required: true
+    env_file: .env
     depends_on:
       postgres:
         condition: service_healthy
@@ -99,6 +94,7 @@ services:
     build:
       context: ./
       target: production-frontend
+    image: aplikacja-konie-frontend
     # ports:
     #   - 5173:5733
     depends_on:

--- a/infra/docker-optimize.md
+++ b/infra/docker-optimize.md
@@ -1,0 +1,7 @@
+# Optimizing docker images
+
+```bash
+docker compose build
+mint build --compose-file=docker-compose.yml --dep-exclude-compose-svc-all --compose-env-file=.env --http-probe=false aplikacja-konie-backend
+mint build --compose-file=docker-compose.yml --dep-exclude-compose-svc-all --compose-env-file=.env aplikacja-konie-frontend 
+```

--- a/infra/docker-optimize.md
+++ b/infra/docker-optimize.md
@@ -1,7 +1,8 @@
 # Optimizing docker images
 
+Backend is not further optimized, because that would require a substantial test suite for every route (100% code coverage).
+
 ```bash
 docker compose build
-mint build --compose-file=docker-compose.yml --dep-exclude-compose-svc-all --compose-env-file=.env --http-probe=false aplikacja-konie-backend
-mint build --compose-file=docker-compose.yml --dep-exclude-compose-svc-all --compose-env-file=.env aplikacja-konie-frontend 
+mint build --tag aplikacja-konie-frontend aplikacja-konie-frontend
 ```


### PR DESCRIPTION
- **infra: minify docker images Use yet another production build layer Downgrade node to stable 22 Use distroless nodejs22 image Run MinT on frontend**
- **infra: optimize docker image sizes**
- **infra: distroless uses glibc vs musl, alpine->slim**
- **infra: conclude that backend cannot be optimized using MinT**
- **infra: Dockerfile use some tag to silence warning**
